### PR TITLE
fix(linha): prevent duplicate linha names on creation

### DIFF
--- a/src/linha/linha.service.ts
+++ b/src/linha/linha.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Linha } from './linha.entity';
@@ -25,9 +25,15 @@ export class LinhaService {
     }
 
     async create(createLinhaDto: CreateLinhaDto): Promise<Linha> {
-        const linha = this.linhaRepository.create(createLinhaDto);
-        return this.linhaRepository.save(linha);
+    const exists = await this.linhaRepository.findOneBy({ nome: createLinhaDto.nome });
+    if (exists) {
+        throw new BadRequestException(`Já existe uma linha com o nome "${createLinhaDto.nome}".`);
     }
+
+    const linha = this.linhaRepository.create(createLinhaDto);
+    return this.linhaRepository.save(linha);
+    }
+
 
     async update(id: number, updateLinhaDto: UpdateLinhaDto): Promise<Linha> {
         const linha = await this.findOne(id);


### PR DESCRIPTION
## Corrige criação duplicada de linhas com o mesmo nome

Impede que uma linha seja criada com um nome já existente no banco de dados.  
Agora, o serviço retorna uma resposta HTTP 400 com uma mensagem amigável.


## Tipo de mudança

* ⬜ Feature
* ✅ **BugFix**
* ⬜ Refatoração
* ⬜ Documentação

## Checklist

* ✅ Corrige comportamento indesejado
* ✅ Código testado localmente
* ✅ Retorna erro HTTP amigável (400) ao tentar duplicar nome
* ✅ Nenhuma funcionalidade existente foi quebrada

## Prints dos testes

![image](https://github.com/user-attachments/assets/90025f7d-7acb-48b6-a535-0dd8acd46bc8)



