### PR TITLE
feat: add Bus module with validation, REST endpoints and line associa…

### DIFF
--- a/src/onibus/dto/create-onibus.dto.ts
+++ b/src/onibus/dto/create-onibus.dto.ts
@@ -1,0 +1,25 @@
+import { IsNotEmpty, IsNumber, IsOptional, IsString, Max, Min } from "class-validator";
+
+
+export class CreateOnibusDto {
+    @IsString()
+    @IsNotEmpty()
+    codigo: string;
+
+    @IsNumber()
+    @Min(-90)
+    @Max(90)
+    lat: number;
+
+    @IsNumber()
+    @Min(-180)
+    @Max(180)
+    lng: number;
+
+    @IsNumber()
+    linhaId: number;
+
+    @IsNumber()
+    @IsOptional()
+    rotaId?: number;
+}

--- a/src/onibus/dto/update-onibus.dto.ts
+++ b/src/onibus/dto/update-onibus.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from "@nestjs/mapped-types";
+import { CreateOnibusDto } from "./create-onibus.dto";
+
+
+export class UpdateOnibusDto extends PartialType(CreateOnibusDto) {}

--- a/src/onibus/onibus.controller.ts
+++ b/src/onibus/onibus.controller.ts
@@ -1,4 +1,35 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post } from '@nestjs/common';
+import { OnibusService } from './onibus.service';
+import { CreateOnibusDto } from './dto/create-onibus.dto';
+import { UpdateOnibusDto } from './dto/update-onibus.dto';
+import { Onibus } from './onibus.entity';
 
 @Controller('onibus')
-export class OnibusController {}
+export class OnibusController {
+    constructor(private readonly onibusService: OnibusService) {}
+
+    @Post()
+    create(@Body() createOnibusDto: CreateOnibusDto): Promise<Onibus> {
+        return this.onibusService.create(createOnibusDto);
+    }
+
+    @Patch(":id")
+    update(
+        @Param('id', ParseIntPipe) id: number,
+        @Body() updateOnibusDto: UpdateOnibusDto,
+    ): Promise<Onibus> {
+        return this.onibusService.update(id, updateOnibusDto);
+    }
+
+    @Get()
+    findAll(): Promise<Onibus[]> {
+        return this.onibusService.findAll();
+    }
+
+    @Get(':id')
+    findOne(
+        @Param('id', ParseIntPipe) id: number
+    ): Promise<Onibus> {
+        return this.onibusService.findOne(id);
+    }
+}

--- a/src/onibus/onibus.entity.ts
+++ b/src/onibus/onibus.entity.ts
@@ -1,0 +1,29 @@
+import { Linha } from "src/linha/linha.entity";
+import { Rota } from "src/rota/rota.entity";
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn, Unique } from "typeorm";
+
+
+
+@Entity('onibus')
+@Unique(['codigo'])
+export class Onibus {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    codigo: string;
+
+    @Column('double precision')
+    lat: number;
+
+    @Column('double precision')
+    lng: number;
+
+    @ManyToOne(() =>  Linha, { onDelete: 'CASCADE' })
+    @JoinColumn({ name: 'linha_id' })
+    linha: Linha;
+
+    @ManyToOne(() => Rota, { onDelete: 'SET NULL', nullable: true })
+    @JoinColumn({ name: 'rota_id' })
+    rota: Rota;
+}

--- a/src/onibus/onibus.module.ts
+++ b/src/onibus/onibus.module.ts
@@ -1,8 +1,13 @@
 import { Module } from '@nestjs/common';
 import { OnibusController } from './onibus.controller';
 import { OnibusService } from './onibus.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Onibus } from './onibus.entity';
+import { Linha } from 'src/linha/linha.entity';
+import { Rota } from 'src/rota/rota.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Onibus, Linha, Rota])],
   controllers: [OnibusController],
   providers: [OnibusService]
 })

--- a/src/onibus/onibus.service.ts
+++ b/src/onibus/onibus.service.ts
@@ -1,4 +1,107 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Onibus } from './onibus.entity';
+import { Repository } from 'typeorm';
+import { Linha } from 'src/linha/linha.entity';
+import { Rota } from 'src/rota/rota.entity';
+import { CreateOnibusDto } from './dto/create-onibus.dto';
+import { UpdateOnibusDto } from './dto/update-onibus.dto';
 
 @Injectable()
-export class OnibusService {}
+export class OnibusService {
+    constructor(
+        @InjectRepository(Onibus)
+        private readonly onibusRepo: Repository<Onibus>,
+        @InjectRepository(Linha)
+        private readonly linhaRepo: Repository<Linha>,
+        @InjectRepository(Rota)
+        private readonly rotaRepo: Repository<Rota>,
+    ) {}
+
+    async create(createOnibusDto: CreateOnibusDto): Promise<Onibus> {
+    const { codigo, linhaId, lat, lng, rotaId } = createOnibusDto;
+
+    const exists = await this.onibusRepo.findOne({ where: { codigo } });
+    if (exists) {
+        throw new ConflictException('Ônibus com este código já existe');
+    }
+
+    const linha = await this.linhaRepo.findOne({ where: { id: linhaId } });
+    if (!linha) {
+        throw new NotFoundException("Linha não encontrada");
+    }
+
+    let rota: Rota | undefined;
+    if (rotaId) {
+        const rotaResult = await this.rotaRepo.findOne({ where: { id: rotaId, linha: { id: linhaId } } });
+        if (!rotaResult) {
+            throw new NotFoundException("Rota não encontrada ou não pertence à linha");
+        }
+        rota = rotaResult;
+    }
+
+    const onibus = this.onibusRepo.create({
+        codigo,
+        lat,
+        lng,
+        linha,
+        rota,
+    });
+
+    return this.onibusRepo.save(onibus);
+    }
+
+    async update(id: number, updateOnibusDto: UpdateOnibusDto): Promise<Onibus> {
+    // Adicione relations: ['linha'] para carregar a relação linha
+    const onibus = await this.onibusRepo.findOne({ 
+        where: { id },
+        relations: ['linha'], // Corrige o erro
+    });
+    if (!onibus) {
+        throw new NotFoundException('Ônibus não encontrado');
+    }
+
+    // Verifica se o novo código já existe (se fornecido)
+    if (updateOnibusDto.codigo && updateOnibusDto.codigo !== onibus.codigo) {
+        const exists = await this.onibusRepo.findOne({ where: { codigo: updateOnibusDto.codigo } });
+        if (exists) {
+            throw new ConflictException('Ônibus com este código já existe');
+        }
+    }
+
+    // Verifica se a nova linha existe (se fornecida)
+    if (updateOnibusDto.linhaId) {
+        const linha = await this.linhaRepo.findOne({ where: { id: updateOnibusDto.linhaId } });
+        if (!linha) {
+            throw new NotFoundException('Linha não encontrada');
+        }
+        onibus.linha = linha;
+    }
+
+    // Verifica se a nova rota existe e pertence à linha (se fornecida)
+    if (updateOnibusDto.rotaId) {
+        const linhaId = updateOnibusDto.linhaId || onibus.linha.id;
+        const rota = await this.rotaRepo.findOne({ where: { id: updateOnibusDto.rotaId, linha: { id: linhaId } } });
+        if (!rota) {
+            throw new NotFoundException('Rota não encontrada ou não pertence à linha');
+        }
+        onibus.rota = rota;
+    }
+
+    Object.assign(onibus, updateOnibusDto);
+    return this.onibusRepo.save(onibus);
+}
+
+    async findAll(): Promise<Onibus[]> {
+        return this.onibusRepo.find({ relations: ['linha', 'rota']})
+    }
+
+    async findOne(id: number): Promise<Onibus> {
+        const onibus = await this.onibusRepo.findOne({ where: { id }, relations: ['linha', 'rota' ]});
+        if (!onibus) {
+            throw new NotFoundException("Ônibus não encontrado");
+        }
+        return onibus;
+    }
+
+}


### PR DESCRIPTION
## Adiciona CRUD básico para o módulo de Ônibus

Cria a entidade `Onibus` com os campos `id`, `codigo`, `lat`, `lng`, `linha_id` (obrigatório) e `rota_id` (opcional).
Foi implementado todo o CRUD com validações, relacionamento com a tabela de `linha` e, se houver, também com `rota`.

* `codigo` é único — não dá pra cadastrar dois ônibus com o mesmo valor.
* `rota_id` é opcional — dá pra salvar um ônibus mesmo que ele não tenha uma rota definida ainda.
* Validações simples nos DTOs (não pode vir campo vazio, por exemplo).
* Todos os endpoints criados: `POST`, `GET`, `GET:id`, `PATCH`.

## Tipo de mudança

* ✅ **Feature**
* ⬜ Bugfix
* ⬜ Refatoração
* ⬜ Documentação

## Checklist

* ✅ Tudo testado local
* ✅ DTOs funcionando e validando certinho
* ✅ Sem quebrar nada do que já existia
* ✅ Integração com Linha e, se tiver, Rota
* ✅ `rota_id` é opcional, como planejado
* ✅ `codigo` é único

## Prints dos testes
![Captura de tela 2025-05-18 144507](https://github.com/user-attachments/assets/fbd3ab1e-2418-4623-b5d0-0451adef60fa)
![Captura de tela 2025-05-18 144551](https://github.com/user-attachments/assets/46e9a9f9-10ee-4322-be29-f50cbd862e6e)
![Captura de tela 2025-05-18 144453](https://github.com/user-attachments/assets/e5262787-f5e4-435f-af93-4c5dae3bc0e0)
![Captura de tela 2025-05-18 144604](https://github.com/user-attachments/assets/d560826e-f9a4-4a7c-abc6-485618d2d0ee)



