### PR TITLE
fix: add turno column to Linha entity to align with DTO and fix schem…

### DIFF
--- a/src/linha/linha.entity.ts
+++ b/src/linha/linha.entity.ts
@@ -1,6 +1,5 @@
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 
-
 @Entity()
 export class Linha {
     @PrimaryGeneratedColumn()
@@ -17,4 +16,7 @@ export class Linha {
 
     @Column()
     tipo: string;
+
+    @Column()
+    turno: string;
 }


### PR DESCRIPTION
## Corrige ausência da coluna `turno` na entidade `Linha`

Adiciona a coluna `turno` à entidade `Linha` para alinhar com o `CreateLinhaDto`, que já incluía o campo `turno` com validação para os valores `'manhã'`, `'tarde'` e `'noite'`. A ausência dessa coluna na entidade causava um erro de sincronização do esquema (`QueryFailedError: a coluna "turno" da relação "linha" contém valores nulos`). 

A sincronização do esquema agora funciona corretamente, e a validação no DTO continua garantindo que apenas valores válidos sejam aceitos.

## Tipo de mudança

* ⬜ **Feature**
* ✅ **Bugfix**
* ⬜ Refatoração
* ⬜ Documentação

## Checklist

* ✅ Tudo testado localmente
* ✅ DTOs funcionando e validando certinho
* ✅ Sem quebrar nada do que já existia
* ✅ Coluna `turno` adicionada à entidade `Linha`
* ✅ Sincronização do esquema corrigida

## Prints dos testes
![image](https://github.com/user-attachments/assets/ead6d27e-89ba-4c1a-b9f3-59faa2cb4f6d)
![image](https://github.com/user-attachments/assets/1c346457-3b2c-49fb-a0f3-0ae98f77c2ad)

