### PR TITLE
feat(user): add login endpoint using only registration number

### DIFF
--- a/src/user/dto/login.dto.ts
+++ b/src/user/dto/login.dto.ts
@@ -1,0 +1,8 @@
+import { IsNotEmpty, IsNumberString, MinLength } from "class-validator";
+
+export class LoginDto {
+    @IsNotEmpty()
+    @IsNumberString()
+    @MinLength(10)
+    matricula: string;
+}

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,8 +1,8 @@
+// user.controller.ts
 import { Body, Controller, Get, Param, Post } from "@nestjs/common";
 import { CreateUserDto } from "./dto/create-user.dto";
+import { LoginDto } from "./dto/login.dto";
 import { UserService } from "./user.service";
-
-
 
 @Controller('usuarios')
 export class UserContrller {
@@ -26,5 +26,10 @@ export class UserContrller {
     @Get(':id')
     findById(@Param('id') id: number) {
         return this.service.findById(id);
+    }
+
+    @Post('login')
+    login(@Body() loginDto: LoginDto) {
+        return this.service.login(loginDto.matricula);
     }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { User } from "./user.entity";
 import { Repository } from "typeorm";
@@ -25,5 +25,15 @@ export class UserService {
 
     findByMatricula(matricula: string) {
         return this.repo.findOneBy({ matricula });
+    }
+
+    async login(matricula: string) {
+        const user = await this.findByMatricula(matricula);
+        if (!user) {
+            throw new NotFoundException('Usuário não encontrado com essa matrícula');
+        }
+
+        // Aqui você pode retornar um token, sessão ou apenas o usuário
+        return user;
     }
 }


### PR DESCRIPTION
## Adiciona endpoint de login baseado apenas na matrícula

Implementa um endpoint específico de `login` no módulo `User`, que aceita exclusivamente a matrícula do usuário. Foi criado um DTO (`LoginDto`) separado, com validações apropriadas (mínimo de 10 dígitos e formato numérico). O serviço realiza a busca do usuário pela matrícula e retorna uma mensagem clara caso o usuário não exista, evitando erro genérico (500).

Esse login simples pode ser estendido posteriormente com autenticação por token, senha ou integração com outros sistemas.

## Tipo de mudança

* ✅ **Feature**
* ⬜ Bugfix
* ⬜ Refatoração
* ⬜ Documentação

## Checklist

* ✅ DTO de login com validações criado (`LoginDto`)
* ✅ Novo endpoint POST `/usuarios/login` implementado
* ✅ Lógica de busca por matrícula integrada ao login
* ✅ Retorno amigável em caso de matrícula inexistente
* ✅ Testado localmente com banco sincronizado
* ✅ Nenhum impacto em endpoints existentes

## Prints dos testes

![image](https://github.com/user-attachments/assets/4ec2feee-636b-4893-98b9-c587c44b0e9c)
![image](https://github.com/user-attachments/assets/c91350c8-0a68-495c-9dff-3ae9d18a3ccf)
![image](https://github.com/user-attachments/assets/c465e217-fffe-461e-a9a1-9169542a8809)

